### PR TITLE
refactor: optimize Docker build with caching (using cargo chef) + fix build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,47 @@
+# This image uses cargo-chef to build the application in order to compile
+# the dependencies apart from the main application. This allows the compiled
+# dependencies to be cached in the Docker layer and greatly reduce the
+# build time when there isn't any dependency changes.
+#
+# https://github.com/LukeMathWalker/cargo-chef
+
 ARG BUILDER_DIR=/srv/rgb
 
-
-FROM rust:1.59.0-slim-bullseye as builder
+# Base image
+FROM rust:1.59.0-slim-bullseye as chef
 
 ARG SRC_DIR=/usr/local/src/rgb
 ARG BUILDER_DIR
 
-WORKDIR "$SRC_DIR"
+RUN apt-get update && apt-get install -y build-essential
 
-COPY doc ${SRC_DIR}/doc
-COPY shell ${SRC_DIR}/shell
-COPY src ${SRC_DIR}/src
-COPY build.rs Cargo.lock Cargo.toml codecov.yml config_spec.toml \
-     LICENSE license_header README.md ${SRC_DIR}/
+RUN rustup default stable
+RUN rustup update
+RUN cargo install cargo-chef --locked
 
-WORKDIR ${SRC_DIR}
+WORKDIR $SRC_DIR
 
-RUN mkdir "${BUILDER_DIR}"
+# Cargo chef step that analyzes the project to determine the minimum subset of
+# files (Cargo.lock and Cargo.toml manifests) required to build it and cache
+# dependencies
+FROM chef AS planner
 
-RUN cargo install --path . --root "${BUILDER_DIR}" --bins --all-features
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
+FROM chef AS builder
 
-FROM debian:bullseye-slim
+COPY --from=planner $SRC_DIR/recipe.json recipe.json
+
+# Build dependencies - this is the caching Docker layer
+RUN cargo chef cook --release --recipe-path recipe.json --target-dir "${BUILDER_DIR}"
+
+# Copy all files and build application
+COPY . .
+RUN cargo build --release --target-dir "${BUILDER_DIR}" --bins --all-features
+
+# Final image with binaries
+FROM debian:bullseye-slim as final
 
 ARG BUILDER_DIR
 ARG BIN_DIR=/usr/local/bin
@@ -32,9 +52,13 @@ RUN adduser --home "${DATA_DIR}" --shell /bin/bash --disabled-login \
         --gecos "${USER} user" ${USER}
 
 COPY --from=builder --chown=${USER}:${USER} \
-     "${BUILDER_DIR}/bin/" "${BIN_DIR}"
+     "${BUILDER_DIR}/release" "${BIN_DIR}"
 
 WORKDIR "${BIN_DIR}"
+
+# Remove build artifacts in order to keep only the binaries
+RUN rm -rf */ *.d
+
 USER ${USER}
 
 VOLUME "$DATA_DIR"


### PR DESCRIPTION
This PR fixes some Docker build issues and allows us to build the dependencies separated from the main application. This allows the Docker layer compiling dependencies to be cached and reused in later builds, greatly reducing the build time when there isn't any dependency changes. It uses [`cargo-chef`](https://github.com/LukeMathWalker/cargo-chef) (the source code is pretty simple and straightforward).

I've done the same for [BP Node](https://github.com/BP-WG/bp-node), [LNP Node](https://github.com/LNP-WG/lnp-node), [Storm Node](https://github.com/Storm-WG/storm-node) and [Store Service](https://github.com/Storm-WG/storm-node). I've been building the whole stack with that this morning, it is all working well so far. As the changes for the other repos Dockerfiles are substantially identical, I'm first opening this one PR to review.