### PR TITLE
Save Anchor information after transfer finalize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/*.rs.bk
 
 .idea
+.vscode
 
 # Temporary directory for debug data storage
 /data

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -163,6 +163,11 @@ pub enum TransferCommand {
         /// The final PSBT (not modified).
         psbt: PathBuf,
 
+        /// Output file to save the PSBT updated with state transition(s)
+        /// information. If not given, the source PSBT file is overwritten.
+        #[clap(short = 'o', long = "out")]
+        psbt_out: Option<PathBuf>,
+
         /// State transfer consignment draft file prepared with `compose` command.
         consignment_in: PathBuf,
 

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -22,7 +22,7 @@ use psbt::Psbt;
 use rgb::schema::TransitionType;
 use rgb::{Contract, ContractId, ContractState, ContractStateMap, SealEndpoint, StateTransfer};
 
-use crate::messages::HelloReq;
+use crate::messages::{HelloReq, TransferFinalize};
 use crate::{
     AcceptReq, BusMsg, ComposeReq, ContractValidity, Error, FailureCode, OutpointFilter, RpcMsg,
     ServiceId, TransferReq,
@@ -224,7 +224,7 @@ impl Client {
         psbt: Psbt,
         beneficiary: Option<NodeAddr>,
         progress: impl Fn(String),
-    ) -> Result<StateTransfer, Error> {
+    ) -> Result<TransferFinalize, Error> {
         self.request(RpcMsg::Transfer(TransferReq {
             consignment,
             endseals,
@@ -233,7 +233,7 @@ impl Client {
         }))?;
         loop {
             match self.response()?.failure_to_error()? {
-                RpcMsg::StateTransfer(transfer) => return Ok(transfer),
+                RpcMsg::StateTransferFinalize(transfer) => return Ok(transfer),
                 RpcMsg::Progress(info) => progress(info),
                 _ => return Err(Error::UnexpectedServerResponse),
             }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -31,7 +31,8 @@ pub use client::Client;
 pub use error::{Error, FailureCode};
 pub(crate) use messages::BusMsg;
 pub use messages::{
-    AcceptReq, ComposeReq, ContractValidity, HelloReq, OutpointFilter, RpcMsg, TransferReq,
+    AcceptReq, ComposeReq, ContractValidity, HelloReq, OutpointFilter, RpcMsg, TransferFinalize,
+    TransferReq,
 };
 pub use service_id::ServiceId;
 

--- a/rpc/src/messages.rs
+++ b/rpc/src/messages.rs
@@ -91,6 +91,9 @@ pub enum RpcMsg {
     #[display("state_transfer(...)")]
     StateTransfer(StateTransfer),
 
+    #[display("state_transfer_finalize(...)")]
+    StateTransferFinalize(TransferFinalize),
+
     #[display("progress(\"{0}\")")]
     #[from]
     Progress(String),
@@ -189,4 +192,12 @@ pub struct TransferReq {
 
 impl From<&str> for RpcMsg {
     fn from(s: &str) -> Self { RpcMsg::Progress(s.to_owned()) }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Display)]
+#[derive(NetworkEncode, NetworkDecode)]
+#[display("transfer_complete(...)")]
+pub struct TransferFinalize {
+    pub consignment: StateTransfer,
+    pub psbt: Psbt,
 }

--- a/shell/_rgb-cli
+++ b/shell/_rgb-cli
@@ -251,6 +251,8 @@ _arguments "${_arguments_options[@]}" \
 '--send=[Bifrost server to send state transfer to]:SEND: ' \
 '*-e+[Beneficiary blinded TXO seal - or witness transaction output numbers containing allocations for the beneficiary]:ENDSEALS: ' \
 '*--endseal=[Beneficiary blinded TXO seal - or witness transaction output numbers containing allocations for the beneficiary]:ENDSEALS: ' \
+'-o+[Output file to save the PSBT updated with state transition(s) information. If not given, the source PSBT file is overwritten]:PSBT_OUT: ' \
+'--out=[Output file to save the PSBT updated with state transition(s) information. If not given, the source PSBT file is overwritten]:PSBT_OUT: ' \
 '-R+[ZMQ socket for connecting daemon RPC interface]:CONNECT: ' \
 '--rpc=[ZMQ socket for connecting daemon RPC interface]:CONNECT: ' \
 '-n+[Blockchain to use]:CHAIN: ' \

--- a/shell/_rgb-cli.ps1
+++ b/shell/_rgb-cli.ps1
@@ -207,6 +207,8 @@ Register-ArgumentCompleter -Native -CommandName 'rgb-cli' -ScriptBlock {
             [CompletionResult]::new('--send', 'send', [CompletionResultType]::ParameterName, 'Bifrost server to send state transfer to')
             [CompletionResult]::new('-e', 'e', [CompletionResultType]::ParameterName, 'Beneficiary blinded TXO seal - or witness transaction output numbers containing allocations for the beneficiary')
             [CompletionResult]::new('--endseal', 'endseal', [CompletionResultType]::ParameterName, 'Beneficiary blinded TXO seal - or witness transaction output numbers containing allocations for the beneficiary')
+            [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'Output file to save the PSBT updated with state transition(s) information. If not given, the source PSBT file is overwritten')
+            [CompletionResult]::new('--out', 'out', [CompletionResultType]::ParameterName, 'Output file to save the PSBT updated with state transition(s) information. If not given, the source PSBT file is overwritten')
             [CompletionResult]::new('-R', 'R', [CompletionResultType]::ParameterName, 'ZMQ socket for connecting daemon RPC interface')
             [CompletionResult]::new('--rpc', 'rpc', [CompletionResultType]::ParameterName, 'ZMQ socket for connecting daemon RPC interface')
             [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Blockchain to use')

--- a/shell/rgb-cli.bash
+++ b/shell/rgb-cli.bash
@@ -586,7 +586,7 @@ _rgb-cli() {
             return 0
             ;;
         rgb__cli__transfer__finalize)
-            opts="-s -e -h -R -n -v --send --endseal --help --rpc --chain --verbose <PSBT> <CONSIGNMENT_IN> <CONSIGNMENT_OUT>"
+            opts="-s -e -o -h -R -n -v --send --endseal --out --help --rpc --chain --verbose <PSBT> <CONSIGNMENT_IN> <CONSIGNMENT_OUT>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -605,6 +605,14 @@ _rgb-cli() {
                     return 0
                     ;;
                 -e)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --out)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -o)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/src/bucketd/processor.rs
+++ b/src/bucketd/processor.rs
@@ -22,7 +22,7 @@ use rgb::{
     ContractStateMap, Disclosure, Genesis, InmemConsignment, Node, NodeId, Schema, SchemaId,
     SealEndpoint, StateTransfer, Transition, TransitionBundle, Validator, Validity,
 };
-use rgb_rpc::OutpointFilter;
+use rgb_rpc::{OutpointFilter, TransferFinalize};
 use storm::chunk::ChunkIdExt;
 use storm::{ChunkId, Container, ContainerId};
 use strict_encoding::StrictDecode;
@@ -363,7 +363,7 @@ impl Runtime {
         mut consignment: StateTransfer,
         endseals: Vec<SealEndpoint>,
         mut psbt: Psbt,
-    ) -> Result<StateTransfer, DaemonError> {
+    ) -> Result<TransferFinalize, DaemonError> {
         let contract_id = consignment.contract_id();
         info!("Finalizing transfer for {}", contract_id);
 
@@ -395,7 +395,7 @@ impl Runtime {
         let disclosure = Disclosure::with(anchor, bundles, None);
         self.store.store_sten(db::DISCLOSURES, txid, &disclosure)?;
 
-        Ok(consignment)
+        Ok(TransferFinalize { consignment, psbt })
     }
 }
 

--- a/src/bucketd/service.rs
+++ b/src/bucketd/service.rs
@@ -391,7 +391,7 @@ impl Runtime {
                     // 1. Containerize consignment
                     // TODO: Make consignment containerization part of the RGB stdlib; use logical,
                     //       not a size-chunking
-                    let data = transfer.strict_serialize()?;
+                    let data = transfer.consignment.strict_serialize()?;
                     let mut chunk_ids = MediumVec::new();
                     let size = data.len() as u64;
                     for piece in data.chunks(u24::MAX.into_usize()) {
@@ -441,7 +441,8 @@ impl Runtime {
                     };
                     self.send_storm(endpoints, StormMsg::SendContainer(addressed_msg))?;
                 }
-                let _ = self.send_rpc(endpoints, client_id, RpcMsg::StateTransfer(transfer));
+                let _ =
+                    self.send_rpc(endpoints, client_id, RpcMsg::StateTransferFinalize(transfer));
                 self.send_ctl(endpoints, ServiceId::rgbd(), CtlMsg::ProcessingComplete)?
             }
         }


### PR DESCRIPTION
I tried to reproduce the steps of the "rgb-demo" written [here](https://github.com/LNP-BP/nodes/blob/master/contrib/demo-rgb.sh), but the final step `rgb consignment validate` does not work as expected.

After investigating, I found the reason: The step `dbc commit` is unnecessary because the  `rgb-cli transfer finalize `  already add the anchor information into psbt file.

I changed the code to save psbt with anchor information.