### PR TITLE
Fix outpoint_state index store

### DIFF
--- a/src/bucketd/processor.rs
+++ b/src/bucketd/processor.rs
@@ -198,7 +198,10 @@ impl Runtime {
         self.store.store_merge(db::GENESIS, contract_id, genesis.clone())?;
         for seal in genesis.revealed_seals().unwrap_or_default() {
             debug!("Adding outpoint for seal {}", seal);
-            let index_id = ChunkId::with_fixed_fragments(seal.txid, seal.vout);
+            let index_id = ChunkId::with_fixed_fragments(
+                seal.txid.expect("genesis with vout-based seal which passed schema validation"),
+                seal.vout,
+            );
             self.store.insert_into_set(db::OUTPOINTS, index_id, contract_id)?;
         }
         debug!("Storing contract self-reference");


### PR DESCRIPTION
Found a bug calling `outpoint_state`. By calling the method with an empty `Vec<OutPoint>` it correctly returns known allocations, but by calling it with some specific outpoints it returns no allocations.

Investigating this I've found that when storing the index into the DB:
```rust
for seal in genesis.revealed_seals().unwrap_or_default() {
    debug!("Adding outpoint for seal {}", seal);
    let index_id = ChunkId::with_fixed_fragments(seal.txid, seal.vout);
    self.store.insert_into_set(db::OUTPOINTS, index_id, contract_id)?;
}
```
`ChunkId::with_fixed_fragments` receives a `Option<Txid>`.


While, when searching for specific outpoints:

```rust
let indexes = if outpoints.is_empty() {
    self.store.ids(db::OUTPOINTS)?
} else {
    outpoints
        .iter()
        .map(|outpoint| ChunkId::with_fixed_fragments(outpoint.txid, outpoint.vout))
        .collect()
};
```
`ChunkId::with_fixed_fragments` receives a `Txid`.


I've fixed the bug on the store-side by unwrapping the `Option`, since I believe the TXID should always be present at that point, I hope that's correct.

I manually tested it and can confirm that with this fix `outpoint_state` filter works as expected.

