### PR TITLE
Fix bucketd and stormd integration

### DIFF
--- a/src/bus/services.rs
+++ b/src/bus/services.rs
@@ -46,20 +46,20 @@ pub enum ServiceId {
 
     #[display("peerd<{0}>")]
     #[from]
-    #[strict_encoding(value = 0x21)]
+    #[strict_encoding(value = 0x22)]
     Peer(NodeAddr),
 
     #[display("channel<{0:#x}>")]
     #[from]
-    #[strict_encoding(value = 0x22)]
+    #[strict_encoding(value = 0x23)]
     Channel(ChannelId),
 
     #[display("msgapp<{0}>")]
-    #[strict_encoding(value = 0x24)]
+    #[strict_encoding(value = 0x25)]
     MsgApp(BifrostApp),
 
     #[display("chapp<{0}>")]
-    #[strict_encoding(value = 0x23)]
+    #[strict_encoding(value = 0x24)]
     ChannelApp(BifrostApp),
 
     #[display("other<{0}>")]


### PR DESCRIPTION
**Description**

After running `rgb-cli finalize` with --send parameter, an error occurs ("ESB request processing error: ESB error: provided service bus id STORM is unknown").

This error occurs because the storm bus configuration is not passed to bucketd daemon and incorrect strict enconding service ids.

This PR fixies this.