### PR TITLE
Recreate header_containers containers  tables on start rgbd 

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -15,8 +15,6 @@ pub const GENESIS: &'static str = "genesis";
 pub const TRANSITIONS: &'static str = "transitions";
 pub const ANCHORS: &'static str = "anchors";
 pub const EXTENSIONS: &'static str = "extensions";
-pub const ATTACHMENT_CHUNKS: &'static str = "chunks";
-pub const ATTACHMENT_INDEX: &'static str = "attachments";
 pub const ALU_LIBS: &'static str = "alu";
 
 pub const OUTPOINTS: &'static str = "outpoints";
@@ -25,6 +23,12 @@ pub const TRANSITION_WITNESS: &'static str = "transition_txid";
 pub const CONTRACT_TRANSITIONS: &'static str = "contract_transitions";
 
 pub const DISCLOSURES: &'static str = "disclosures";
+
+// Storm intgration
+pub const ATTACHMENT_CHUNKS: &'static str = "chunks";
+pub const ATTACHMENT_INDEX: &'static str = "attachments";
+pub const ATTACHMENT_CONTAINER_HEADERS: &'static str = "container_headers";
+pub const ATTACHMENT_CONTAINERS: &'static str = "containers";
 
 pub(crate) trait StoreRpcExt {
     fn retrieve_sten<T>(

--- a/src/rgbd/service.rs
+++ b/src/rgbd/service.rs
@@ -108,6 +108,8 @@ impl Runtime {
             db::TRANSITION_WITNESS,
             db::CONTRACT_TRANSITIONS,
             db::DISCLOSURES,
+            db::ATTACHMENT_CONTAINER_HEADERS,
+            db::ATTACHMENT_CONTAINERS,
         ] {
             store.use_table(table.to_owned()).map_err(LaunchError::from)?;
         }


### PR DESCRIPTION
**Description**

I made fault tolerance tests of the stored daemon and found unexpected behavior.

After erasing the disk volume of the stored daemon, I tried to execute `rgb-cli finalize`, and _UnknownTable_ error occurred with the  'containers' and 'container_headers' tables.

I added the two tables on the "use or recreate" process on start the rgbd to fix this.