### PR TITLE
add process_disclosure API

### DIFF
--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeSet;
 use std::thread::sleep;
 use std::time::Duration;
 
-use bitcoin::OutPoint;
+use bitcoin::{OutPoint, Txid};
 use internet2::addr::{NodeAddr, ServiceAddr};
 use internet2::ZmqSocketType;
 use lnpbp::chain::Chain;
@@ -255,6 +255,21 @@ impl Client {
                 RpcMsg::Invalid(status) => return Ok(ContractValidity::Invalid(status)),
                 RpcMsg::UnresolvedTxids(txids) => return Ok(ContractValidity::UnknownTxids(txids)),
                 RpcMsg::Success(_) => return Ok(ContractValidity::Valid),
+                RpcMsg::Progress(info) => progress(info),
+                _ => return Err(Error::UnexpectedServerResponse),
+            }
+        }
+    }
+
+    pub fn process_disclosure(
+        &mut self,
+        txid: Txid,
+        progress: impl Fn(String),
+    ) -> Result<bool, Error> {
+        self.request(RpcMsg::ProcessDisclosure(txid))?;
+        loop {
+            match self.response()?.failure_to_error()? {
+                RpcMsg::Success(_) => return Ok(true),
                 RpcMsg::Progress(info) => progress(info),
                 _ => return Err(Error::UnexpectedServerResponse),
             }

--- a/rpc/src/messages.rs
+++ b/rpc/src/messages.rs
@@ -68,6 +68,9 @@ pub enum RpcMsg {
     #[display("accept_transfer(...)")]
     ConsumeTransfer(AcceptReq<TransferConsignment>),
 
+    #[display("process_disclosure({0})")]
+    ProcessDisclosure(Txid),
+
     #[display(inner)]
     Transfer(TransferReq),
 

--- a/src/bucketd/service.rs
+++ b/src/bucketd/service.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use amplify::num::u24;
 use bitcoin::secp256k1::rand::random;
-use bitcoin::OutPoint;
+use bitcoin::{OutPoint, Txid};
 use commit_verify::ConsensusCommit;
 use electrum_client::Client as ElectrumClient;
 use internet2::addr::NodeAddr;
@@ -39,7 +39,7 @@ use strict_encoding::{MediumVec, StrictEncode};
 
 use crate::bus::{
     BusMsg, ConsignReq, CtlMsg, DaemonId, Endpoints, FinalizeTransferReq, OutpointStateReq,
-    ProcessReq, Responder, ServiceBus, ServiceId, ValidityResp,
+    ProcessDisclosureReq, ProcessReq, Responder, ServiceBus, ServiceId, ValidityResp,
 };
 use crate::{Config, DaemonError, LaunchError};
 
@@ -178,6 +178,9 @@ impl Runtime {
             }) => {
                 self.handle_consignment(endpoints, client_id, consignment, force)?;
             }
+            CtlMsg::ProcessDisclosure(ProcessDisclosureReq { client_id, txid }) => {
+                self.handle_disclosure(endpoints, client_id, txid)?;
+            }
             CtlMsg::ProcessTransferContainer(container_id) => {
                 self.handle_container(endpoints, container_id)?;
             }
@@ -305,6 +308,25 @@ impl Runtime {
                     consignment_id: id,
                     status,
                 })?
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_disclosure(
+        &mut self,
+        endpoints: &mut Endpoints,
+        client_id: ClientId,
+        txid: Txid,
+    ) -> Result<(), DaemonError> {
+        match self.process_disclosure(txid) {
+            Err(err) => {
+                let _ = self.send_rpc(endpoints, client_id, err);
+                self.send_ctl(endpoints, ServiceId::rgbd(), CtlMsg::ProcessingFailed)?
+            }
+            Ok(_) => {
+                let _ = self.send_rpc(endpoints, client_id, RpcMsg::success());
+                self.send_ctl(endpoints, ServiceId::rgbd(), CtlMsg::ProcessingComplete)?
             }
         }
         Ok(())

--- a/src/bus/ctl.rs
+++ b/src/bus/ctl.rs
@@ -10,7 +10,7 @@
 
 use std::collections::BTreeSet;
 
-use bitcoin::OutPoint;
+use bitcoin::{OutPoint, Txid};
 use internet2::addr::NodeAddr;
 use microservices::esb::ClientId;
 use psbt::Psbt;
@@ -35,6 +35,9 @@ pub enum CtlMsg {
 
     #[display("process_transfer({0})")]
     ProcessTransfer(ProcessReq<TransferConsignment>),
+
+    #[display("process_disclosure({0})")]
+    ProcessDisclosure(ProcessDisclosureReq),
 
     #[display("process_transfer_container({0})")]
     ProcessTransferContainer(ContainerId),
@@ -68,6 +71,13 @@ pub struct ProcessReq<T: ConsignmentType> {
     pub client_id: ClientId,
     pub consignment: InmemConsignment<T>,
     pub force: bool,
+}
+
+#[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]
+#[display("{client_id}, txid = {txid}, ...")]
+pub struct ProcessDisclosureReq {
+    pub client_id: ClientId,
+    pub txid: Txid,
 }
 
 #[derive(Clone, Debug, Display, StrictEncode, StrictDecode)]

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -16,7 +16,8 @@ use rgb_rpc::RpcMsg;
 use storm_ext::ExtMsg as StormMsg;
 
 pub use self::ctl::{
-    ConsignReq, CtlMsg, FinalizeTransferReq, OutpointStateReq, ProcessReq, ValidityResp,
+    ConsignReq, CtlMsg, FinalizeTransferReq, OutpointStateReq, ProcessDisclosureReq, ProcessReq,
+    ValidityResp,
 };
 pub use self::services::{DaemonId, ServiceId};
 pub(crate) use self::services::{Endpoints, Responder, ServiceBus};


### PR DESCRIPTION
Closes #206 by adding an API, `process_disclosure`, that gets the transfer TXID ad uses it to retrieve its associated disclosure and process it saving all relevant data into the DB.

Moreover this PR introduces a commit that changes the key used to save `BUNDLES` into the DB, from the `witness_txid` to a chunk of `contract_id` and `witness_txid`, allowing the send of more assets with the same TX.

I haven't added a CLI command for the new API yet, since I'm not sure the API and related naming will be accepted, but once we'll agree on details I will be happy to add that.