### PR TITLE
CLI transfer combine: set_rgb_contract for blank

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -244,6 +244,8 @@ impl Exec for Opts {
                         if cid == contract_id {
                             continue;
                         }
+                        let contract = client.contract(cid, vec![], progress)?;
+                        psbt.set_rgb_contract(contract)?;
                         let blank_bundle = TransitionBundle::blank(&outpoint_map, &bmap! {})?;
                         for (transition, indexes) in blank_bundle.revealed_iter() {
                             psbt.push_rgb_transition(transition.clone())?;


### PR DESCRIPTION
Small fix to `TransferCommand::Combine` CLI command. While constructing blank transitions we also need to set their related rgb contracts to the psbt, otherwise the command `psbt.rgb_bundle_to_lnpbp4()` (from [rgb-std](https://github.com/RGB-WG/rgb-std/blob/master/src/psbt.rs#L230)), when collecting bundles by iterating on `self.rgb_contract_ids()`, will not collect blank bundles and therefore blank transitions will not complete succesfully.