### PR TITLE
Add finalize_transfers API

### DIFF
--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -32,8 +32,8 @@ pub use client::Client;
 pub use error::{Error, FailureCode};
 pub(crate) use messages::BusMsg;
 pub use messages::{
-    AcceptReq, ComposeReq, ContractValidity, HelloReq, OutpointFilter, RpcMsg, TransferFinalize,
-    TransferReq,
+    AcceptReq, ComposeReq, ContractValidity, FinalizeTransfersRes, HelloReq, OutpointFilter,
+    RpcMsg, TransferFinalize, TransferReq, TransfersReq,
 };
 pub use reveal::Reveal;
 pub use service_id::ServiceId;

--- a/rpc/src/messages.rs
+++ b/rpc/src/messages.rs
@@ -74,6 +74,9 @@ pub enum RpcMsg {
     #[display(inner)]
     Transfer(TransferReq),
 
+    #[display(inner)]
+    FinalizeTransfers(TransfersReq),
+
     #[display("memorize_seal({0})")]
     MemorizeSeal(seal::Revealed),
 
@@ -96,6 +99,9 @@ pub enum RpcMsg {
 
     #[display("state_transfer_finalize(...)")]
     StateTransferFinalize(TransferFinalize),
+
+    #[display("state_transfer_finalize(...)")]
+    FinalizedTransfers(FinalizeTransfersRes),
 
     #[display("progress(\"{0}\")")]
     #[from]
@@ -194,14 +200,30 @@ pub struct TransferReq {
     pub beneficiary: Option<NodeAddr>,
 }
 
-impl From<&str> for RpcMsg {
-    fn from(s: &str) -> Self { RpcMsg::Progress(s.to_owned()) }
-}
-
 #[derive(Clone, PartialEq, Eq, Debug, Display)]
 #[derive(NetworkEncode, NetworkDecode)]
 #[display("transfer_complete(...)")]
 pub struct TransferFinalize {
     pub consignment: StateTransfer,
     pub psbt: Psbt,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Display)]
+#[derive(NetworkEncode, NetworkDecode)]
+#[display("transfers_req(...)")]
+pub struct TransfersReq {
+    pub transfers: Vec<(StateTransfer, Vec<SealEndpoint>)>,
+    pub psbt: Psbt,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Display)]
+#[derive(NetworkEncode, NetworkDecode)]
+#[display("finalize_transfers_res(...)")]
+pub struct FinalizeTransfersRes {
+    pub consignments: Vec<StateTransfer>,
+    pub psbt: Psbt,
+}
+
+impl From<&str> for RpcMsg {
+    fn from(s: &str) -> Self { RpcMsg::Progress(s.to_owned()) }
 }

--- a/src/bus/ctl.rs
+++ b/src/bus/ctl.rs
@@ -55,6 +55,9 @@ pub enum CtlMsg {
     FinalizeTransfer(FinalizeTransferReq),
 
     #[display(inner)]
+    FinalizeTransfers(FinalizeTransfersReq),
+
+    #[display(inner)]
     #[from]
     Validity(ValidityResp),
 
@@ -116,4 +119,13 @@ pub struct FinalizeTransferReq {
     pub endseals: Vec<SealEndpoint>,
     pub psbt: Psbt,
     pub beneficiary: Option<NodeAddr>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Display)]
+#[derive(NetworkEncode, NetworkDecode)]
+#[display("finalize_transfers({client_id}, ...)")]
+pub struct FinalizeTransfersReq {
+    pub client_id: ClientId,
+    pub transfers: Vec<(StateTransfer, Vec<SealEndpoint>)>,
+    pub psbt: Psbt,
 }

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -16,8 +16,8 @@ use rgb_rpc::RpcMsg;
 use storm_ext::ExtMsg as StormMsg;
 
 pub use self::ctl::{
-    ConsignReq, CtlMsg, FinalizeTransferReq, OutpointStateReq, ProcessDisclosureReq, ProcessReq,
-    ValidityResp,
+    ConsignReq, CtlMsg, FinalizeTransferReq, FinalizeTransfersReq, OutpointStateReq,
+    ProcessDisclosureReq, ProcessReq, ValidityResp,
 };
 pub use self::services::{DaemonId, ServiceId};
 pub(crate) use self::services::{Endpoints, Responder, ServiceBus};


### PR DESCRIPTION
In order to finalize an RGB transfer that sends more than one asset, I added a new `finalize_transfers` API. I haven't changed the existing finalize transfer API since I don't want to break compatibility, but maybe in the future we can deprecate that in favor of this API. Moreover I haven't implemented the `beneficiary` part to save some implementation time (since currently we are not using that feature) and the respective CLI command, but I guess we can open some "good first" issues for these features.