### PR TITLE
do not build shell code on docs.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,7 @@
 // You should have received a copy of the MIT License along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
+use std::env;
 use std::fs;
 
 use clap::IntoApp;
@@ -29,16 +30,17 @@ pub mod bucketd {
 }
 
 fn main() -> Result<(), configure_me_codegen::Error> {
-    let outdir = "./shell";
-
-    fs::create_dir_all(outdir).expect("failed to create shell dir");
-    for app in [rgbd::Opts::command(), bucketd::Opts::command()].iter_mut() {
-        let name = app.get_name().to_string();
-        generate_to(Bash, app, &name, &outdir)?;
-        generate_to(PowerShell, app, &name, &outdir)?;
-        generate_to(Zsh, app, &name, &outdir)?;
+    if env::var("DOCS_RS").is_err() {
+        let outdir = "./shell";
+        fs::create_dir_all(outdir).expect("failed to create shell dir");
+        for app in [rgbd::Opts::command(), bucketd::Opts::command()].iter_mut() {
+            let name = app.get_name().to_string();
+            generate_to(Bash, app, &name, &outdir)?;
+            generate_to(PowerShell, app, &name, &outdir)?;
+            generate_to(Zsh, app, &name, &outdir)?;
+        }
+        // configure_me_codegen::build_script_auto()
     }
 
-    // configure_me_codegen::build_script_auto()
     Ok(())
 }


### PR DESCRIPTION
I've just noticed that also rgb-node documentation build [fails](https://docs.rs/crate/rgb_node/0.8.1/builds/674123).

This PR applies the same fix proposed here https://github.com/Storm-WG/storm-stored/pull/8

@dr-orlovsky probably before releasing a v0.8.2 it's better if I check if there are other libraries we depend on that need the same fix, I'll let you know