### PR TITLE
fix electrum-client usage for lib bug

### DIFF
--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -34,6 +34,8 @@ pub enum FailureCode {
 
     Finalize = 0x15,
 
+    ElectrumConnectivity = 0x16,
+
     UnexpectedRequest = 0x80,
 
     /// Daemon launcher error

--- a/src/bucketd/service.rs
+++ b/src/bucketd/service.rs
@@ -17,7 +17,6 @@ use amplify::num::u24;
 use bitcoin::secp256k1::rand::random;
 use bitcoin::{OutPoint, Txid};
 use commit_verify::ConsensusCommit;
-use electrum_client::Client as ElectrumClient;
 use internet2::addr::NodeAddr;
 use internet2::ZmqSocketType;
 use microservices::error::BootstrapError;
@@ -83,7 +82,7 @@ pub fn run(config: Config) -> Result<(), BootstrapError<LaunchError>> {
 pub struct Runtime {
     id: DaemonId,
 
-    pub(crate) electrum: ElectrumClient,
+    pub(crate) electrum_url: String,
 
     pub(crate) store: store_rpc::Client,
 }
@@ -96,15 +95,12 @@ impl Runtime {
 
         let id = random();
 
-        let electrum = ElectrumClient::new(&config.electrum_url)
-            .map_err(|_| LaunchError::ElectrumConnectivity)?;
-
         info!("Bucket runtime started successfully");
 
         Ok(Self {
             id,
             store,
-            electrum,
+            electrum_url: config.electrum_url,
         })
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,9 @@ pub(crate) enum DaemonError {
     #[from(bp::dbc::anchor::Error)]
     Finalize(FinalizeError),
 
+    /// electrum connectivity error. Details: {0}
+    ElectrumConnectivity(String),
+
     /// the container which was requested to be processed is absent in sthe store
     NoContainer(ContainerId),
 
@@ -98,6 +101,7 @@ impl From<DaemonError> for RpcMsg {
             DaemonError::BucketLauncher(_) => FailureCode::Launcher,
             DaemonError::Stash(_) => FailureCode::Stash,
             DaemonError::Finalize(_) => FailureCode::Finalize,
+            DaemonError::ElectrumConnectivity(_) => FailureCode::ElectrumConnectivity,
             DaemonError::NoContainer(_) => FailureCode::Store,
         };
         RpcMsg::Failure(rpc::Failure {


### PR DESCRIPTION
Using iris we've found a bug on `electrum-client` `0.10.2` (should be alredy fixed from `0.11.0` onwards) that prevents using a `Client` instance more than once. This PR recreates a new instance each time it's needed as a fix for the `0.8` series. It also introduces a timeout for the electrum client and a new `ElectrumConnectivity` error.