### PR TITLE
Bump crates in build-dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ shellexpand = { version = "2.1", optional = true }
 
 [build-dependencies]
 amplify = "3.13.0"
-internet2 = "0.8.0"
-microservices = { version = "0.8.0", default-features = false }
+internet2 = "0.8.3"
+microservices = { version = "0.8.10", default-features = false }
 lnpbp = "0.8.0"
 psbt = "0.8.0"
 rgb-std = "0.8.0"


### PR DESCRIPTION
internet2 to 0.8.3.
microservices to 0.8.10.

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>