### PR TITLE
revert electrum-client usage temporary fix

### DIFF
--- a/src/bucketd/processor.rs
+++ b/src/bucketd/processor.rs
@@ -14,7 +14,6 @@ use std::io::Write;
 
 use bitcoin::{OutPoint, Txid};
 use commit_verify::{lnpbp4, CommitConceal, TaggedHash};
-use electrum_client::{Client as ElectrumClient, ConfigBuilder};
 use psbt::Psbt;
 use rgb::psbt::RgbExt;
 use rgb::schema::{OwnedRightType, TransitionType};
@@ -34,8 +33,6 @@ use super::Runtime;
 use crate::amplify::Wrapper;
 use crate::db::{self, StoreRpcExt};
 use crate::DaemonError;
-
-const ELECTRUM_TIMEOUT: u8 = 4;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display, Error, From)]
 #[display(doc_comments)]
@@ -130,15 +127,6 @@ pub enum FinalizeError {
 }
 
 impl Runtime {
-    fn _new_electrum_client(&self) -> Result<ElectrumClient, DaemonError> {
-        let electrum_config = ConfigBuilder::new()
-            .timeout(Some(ELECTRUM_TIMEOUT))
-            .expect("cannot fail since socks5 is unset")
-            .build();
-        ElectrumClient::from_config(&self.electrum_url, electrum_config)
-            .map_err(|e| DaemonError::ElectrumConnectivity(e.to_string()))
-    }
-
     /// Processes incoming transfer downloaded as a container locally
     pub(super) fn process_container(
         &mut self,
@@ -189,7 +177,7 @@ impl Runtime {
         trace!("Starting with contract state {:?}", state);
 
         debug!("Validating consignment {} for contract {}", id, contract_id);
-        let status = Validator::validate(&consignment, &self._new_electrum_client()?);
+        let status = Validator::validate(&consignment, &self.electrum);
         info!("Consignment validation result is {}", status.validity());
 
         match status.validity() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,8 +29,8 @@ pub enum LaunchError {
     #[from]
     StoreConnection(ServerError<store_rpc::FailureCode>),
 
-    /// can't connect to electrum server
-    ElectrumConnectivity,
+    /// electrum connectivity error. Details: {0}
+    ElectrumConnectivity(String),
 }
 
 impl microservices::error::Error for LaunchError {}
@@ -71,9 +71,6 @@ pub(crate) enum DaemonError {
     #[from(bp::dbc::anchor::Error)]
     Finalize(FinalizeError),
 
-    /// electrum connectivity error. Details: {0}
-    ElectrumConnectivity(String),
-
     /// the container which was requested to be processed is absent in sthe store
     NoContainer(ContainerId),
 
@@ -101,7 +98,6 @@ impl From<DaemonError> for RpcMsg {
             DaemonError::BucketLauncher(_) => FailureCode::Launcher,
             DaemonError::Stash(_) => FailureCode::Stash,
             DaemonError::Finalize(_) => FailureCode::Finalize,
-            DaemonError::ElectrumConnectivity(_) => FailureCode::ElectrumConnectivity,
             DaemonError::NoContainer(_) => FailureCode::Store,
         };
         RpcMsg::Failure(rpc::Failure {


### PR DESCRIPTION
This PR reverts most of the code introduced in https://github.com/RGB-WG/rgb-node/pull/227.

Since the upgrade of the electrum-client lib in rgb-node we do not need that temporary fix anymore. 

I haven't simply reverted the PR commit because that also added a timeout to the electrum client configuration that I think will be useful (maybe in the future we could also allow changing that value via config, we could open a "good first issue" for this).
