### PR TITLE
Allow multiple transfers by CLI

### DIFF
--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -11,11 +11,11 @@
 use std::path::PathBuf;
 
 use bitcoin::OutPoint;
-use internet2::addr::{NodeAddr, ServiceAddr};
+use internet2::addr::ServiceAddr;
 use lnpbp::chain::Chain;
 use rgb::schema::TransitionType;
-use rgb::{Contract, ContractId, SealEndpoint};
-use rgb_rpc::{Reveal, RGB_NODE_RPC_ENDPOINT};
+use rgb::{Contract, ContractId};
+use rgb_rpc::{NewTransfer, Reveal, RGB_NODE_RPC_ENDPOINT};
 
 /// Command-line tool for working with RGB node
 #[derive(Parser, Clone, PartialEq, Eq, Debug)]
@@ -151,14 +151,10 @@ pub enum TransferCommand {
     /// (LNP Node).
     #[display("finalize ...")]
     Finalize {
-        /// Bifrost server to send state transfer to
-        #[clap(short, long)]
-        send: Option<NodeAddr>,
-
         /// Beneficiary blinded TXO seal - or witness transaction output numbers
         /// containing allocations for the beneficiary.
         #[clap(short, long = "endseal", required = true)]
-        endseals: Vec<SealEndpoint>,
+        endseal: Vec<NewTransfer>,
 
         /// The final PSBT (not modified).
         psbt: PathBuf,
@@ -167,13 +163,12 @@ pub enum TransferCommand {
         /// information. If not given, the source PSBT file is overwritten.
         #[clap(short = 'o', long = "out")]
         psbt_out: Option<PathBuf>,
+        // /// State transfer consignment draft file prepared with `compose` command.
+        // consignment_in: PathBuf,
 
-        /// State transfer consignment draft file prepared with `compose` command.
-        consignment_in: PathBuf,
-
-        /// Output file to save the final consignment. If not given, the source
-        /// consignment file is overwritten.
-        consignment_out: Option<PathBuf>,
+        // /// Output file to save the final consignment. If not given, the source
+        // /// consignment file is overwritten.
+        // consignment_out: Option<PathBuf>,
     },
 
     /// Validate incoming transfer consignment and consume it into the stash.
@@ -194,7 +189,7 @@ pub enum TransferCommand {
         /// Examples:
         ///
         /// tapret1st@<outpoint>#<blinding_factor>
-        /// opret1st@<outpoint>#<blinding_factor>  
+        /// opret1st@<outpoint>#<blinding_factor>
         #[clap(short, long)]
         reveal: Option<Reveal>,
     },

--- a/rpc/src/client.rs
+++ b/rpc/src/client.rs
@@ -13,7 +13,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use bitcoin::{OutPoint, Txid};
-use internet2::addr::{NodeAddr, ServiceAddr};
+use internet2::addr::ServiceAddr;
 use internet2::ZmqSocketType;
 use lnpbp::chain::Chain;
 use microservices::esb::{self, BusId, ClientId};
@@ -22,10 +22,10 @@ use psbt::Psbt;
 use rgb::schema::TransitionType;
 use rgb::{Contract, ContractId, ContractState, ContractStateMap, SealEndpoint, StateTransfer};
 
-use crate::messages::{FinalizeTransfersRes, HelloReq, TransferFinalize, TransfersReq};
+use crate::messages::{FinalizeTransfersRes, HelloReq, TransfersReq};
 use crate::{
     AcceptReq, BusMsg, ComposeReq, ContractValidity, Error, FailureCode, OutpointFilter, Reveal,
-    RpcMsg, ServiceId, TransferReq,
+    RpcMsg, ServiceId,
 };
 
 // We have just a single service bus (RPC), so we can use any id
@@ -212,29 +212,6 @@ impl Client {
         loop {
             match self.response()?.failure_to_error()? {
                 RpcMsg::StateTransfer(trasfer) => return Ok(trasfer),
-                RpcMsg::Progress(info) => progress(info),
-                _ => return Err(Error::UnexpectedServerResponse),
-            }
-        }
-    }
-
-    pub fn transfer(
-        &mut self,
-        consignment: StateTransfer,
-        endseals: Vec<SealEndpoint>,
-        psbt: Psbt,
-        beneficiary: Option<NodeAddr>,
-        progress: impl Fn(String),
-    ) -> Result<TransferFinalize, Error> {
-        self.request(RpcMsg::Transfer(TransferReq {
-            consignment,
-            endseals,
-            psbt,
-            beneficiary,
-        }))?;
-        loop {
-            match self.response()?.failure_to_error()? {
-                RpcMsg::StateTransferFinalize(transfer) => return Ok(transfer),
                 RpcMsg::Progress(info) => progress(info),
                 _ => return Err(Error::UnexpectedServerResponse),
             }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -36,16 +36,16 @@ pub mod client;
 mod error;
 mod messages;
 mod service_id;
-mod reveal;
+mod structs;
 
 pub use client::Client;
 pub use error::{Error, FailureCode};
 pub(crate) use messages::BusMsg;
 pub use messages::{
     AcceptReq, ComposeReq, ContractValidity, FinalizeTransfersRes, HelloReq, OutpointFilter,
-    RpcMsg, TransferFinalize, TransferReq, TransfersReq,
+    RpcMsg, TransfersReq,
 };
-pub use reveal::Reveal;
 pub use service_id::ServiceId;
+pub use structs::{NewTransfer, Reveal};
 
 pub const RGB_NODE_RPC_ENDPOINT: &str = "0.0.0.0:63963";

--- a/rpc/src/messages.rs
+++ b/rpc/src/messages.rs
@@ -11,7 +11,6 @@
 use std::collections::BTreeSet;
 
 use bitcoin::{OutPoint, Txid};
-use internet2::addr::NodeAddr;
 use internet2::presentation;
 use lnpbp::chain::Chain;
 use microservices::rpc;
@@ -72,9 +71,6 @@ pub enum RpcMsg {
     ProcessDisclosure(Txid),
 
     #[display(inner)]
-    Transfer(TransferReq),
-
-    #[display(inner)]
     FinalizeTransfers(TransfersReq),
 
     #[display("memorize_seal({0})")]
@@ -96,9 +92,6 @@ pub enum RpcMsg {
 
     #[display("state_transfer(...)")]
     StateTransfer(StateTransfer),
-
-    #[display("state_transfer_finalize(...)")]
-    StateTransferFinalize(TransferFinalize),
 
     #[display("state_transfer_finalize(...)")]
     FinalizedTransfers(FinalizeTransfersRes),
@@ -188,24 +181,6 @@ pub struct ComposeReq {
     pub contract_id: ContractId,
     pub include: BTreeSet<TransitionType>,
     pub outpoints: OutpointFilter,
-}
-
-#[derive(Clone, PartialEq, Eq, Debug, Display)]
-#[derive(NetworkEncode, NetworkDecode)]
-#[display("transfer(...)")]
-pub struct TransferReq {
-    pub consignment: StateTransfer,
-    pub endseals: Vec<SealEndpoint>,
-    pub psbt: Psbt,
-    pub beneficiary: Option<NodeAddr>,
-}
-
-#[derive(Clone, PartialEq, Eq, Debug, Display)]
-#[derive(NetworkEncode, NetworkDecode)]
-#[display("transfer_complete(...)")]
-pub struct TransferFinalize {
-    pub consignment: StateTransfer,
-    pub psbt: Psbt,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Display)]

--- a/shell/_rgb-cli
+++ b/shell/_rgb-cli
@@ -247,10 +247,8 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (finalize)
 _arguments "${_arguments_options[@]}" \
-'-s+[Bifrost server to send state transfer to]:SEND: ' \
-'--send=[Bifrost server to send state transfer to]:SEND: ' \
-'*-e+[Beneficiary blinded TXO seal - or witness transaction output numbers containing allocations for the beneficiary]:ENDSEALS: ' \
-'*--endseal=[Beneficiary blinded TXO seal - or witness transaction output numbers containing allocations for the beneficiary]:ENDSEALS: ' \
+'*-e+[Beneficiary blinded TXO seal - or witness transaction output numbers containing allocations for the beneficiary]:ENDSEAL: ' \
+'*--endseal=[Beneficiary blinded TXO seal - or witness transaction output numbers containing allocations for the beneficiary]:ENDSEAL: ' \
 '-o+[Output file to save the PSBT updated with state transition(s) information. If not given, the source PSBT file is overwritten]:PSBT_OUT: ' \
 '--out=[Output file to save the PSBT updated with state transition(s) information. If not given, the source PSBT file is overwritten]:PSBT_OUT: ' \
 '-R+[ZMQ socket for connecting daemon RPC interface]:CONNECT: ' \
@@ -262,8 +260,6 @@ _arguments "${_arguments_options[@]}" \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
 ':psbt -- The final PSBT (not modified):' \
-':consignment-in -- State transfer consignment draft file prepared with `compose` command:' \
-'::consignment-out -- Output file to save the final consignment. If not given, the source consignment file is overwritten:' \
 && ret=0
 ;;
 (consume)

--- a/shell/_rgb-cli.ps1
+++ b/shell/_rgb-cli.ps1
@@ -203,8 +203,6 @@ Register-ArgumentCompleter -Native -CommandName 'rgb-cli' -ScriptBlock {
             break
         }
         'rgb-cli;transfer;finalize' {
-            [CompletionResult]::new('-s', 's', [CompletionResultType]::ParameterName, 'Bifrost server to send state transfer to')
-            [CompletionResult]::new('--send', 'send', [CompletionResultType]::ParameterName, 'Bifrost server to send state transfer to')
             [CompletionResult]::new('-e', 'e', [CompletionResultType]::ParameterName, 'Beneficiary blinded TXO seal - or witness transaction output numbers containing allocations for the beneficiary')
             [CompletionResult]::new('--endseal', 'endseal', [CompletionResultType]::ParameterName, 'Beneficiary blinded TXO seal - or witness transaction output numbers containing allocations for the beneficiary')
             [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'Output file to save the PSBT updated with state transition(s) information. If not given, the source PSBT file is overwritten')

--- a/shell/rgb-cli.bash
+++ b/shell/rgb-cli.bash
@@ -594,20 +594,12 @@ _rgb-cli() {
             return 0
             ;;
         rgb__cli__transfer__finalize)
-            opts="-s -e -o -h -R -n -v --send --endseal --out --help --rpc --chain --verbose <PSBT> <CONSIGNMENT_IN> <CONSIGNMENT_OUT>"
+            opts="-e -o -h -R -n -v --endseal --out --help --rpc --chain --verbose <PSBT>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
-                --send)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                -s)
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
                 --endseal)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0

--- a/src/bucketd/service.rs
+++ b/src/bucketd/service.rs
@@ -9,16 +9,13 @@
 // If not, see <https://opensource.org/licenses/MIT>.
 
 use std::collections::BTreeSet;
-use std::str::FromStr;
 use std::thread;
 use std::time::Duration;
 
-use amplify::num::u24;
 use bitcoin::secp256k1::rand::random;
 use bitcoin::{OutPoint, Txid};
 use commit_verify::ConsensusCommit;
 use electrum_client::{Client as ElectrumClient, ConfigBuilder};
-use internet2::addr::NodeAddr;
 use internet2::ZmqSocketType;
 use microservices::error::BootstrapError;
 use microservices::esb;
@@ -31,18 +28,11 @@ use rgb::{
     StateTransfer, TransferConsignment, Validity,
 };
 use rgb_rpc::{OutpointFilter, Reveal, RpcMsg};
-use stens::AsciiString;
-use storm::{
-    Chunk, Container, ContainerFullId, ContainerHeader, ContainerId, ContainerInfo, MesgId,
-};
-use storm_ext::ExtMsg as StormMsg;
-use storm_rpc::AddressedMsg;
-use strict_encoding::{MediumVec, StrictEncode};
+use storm::ContainerId;
 
 use crate::bus::{
-    BusMsg, ConsignReq, CtlMsg, DaemonId, Endpoints, FinalizeTransferReq, FinalizeTransfersReq,
-    OutpointStateReq, ProcessDisclosureReq, ProcessReq, Responder, ServiceBus, ServiceId,
-    ValidityResp,
+    BusMsg, ConsignReq, CtlMsg, DaemonId, Endpoints, FinalizeTransfersReq, OutpointStateReq,
+    ProcessDisclosureReq, ProcessReq, Responder, ServiceBus, ServiceId, ValidityResp,
 };
 use crate::{Config, DaemonError, LaunchError};
 
@@ -236,23 +226,6 @@ impl Runtime {
                 self.handle_outpoint_state(endpoints, client_id, outpoints)?;
             }
 
-            CtlMsg::FinalizeTransfer(FinalizeTransferReq {
-                client_id,
-                consignment,
-                endseals,
-                psbt,
-                beneficiary,
-            }) => {
-                self.handle_finalize_transfer(
-                    endpoints,
-                    client_id,
-                    consignment,
-                    endseals,
-                    psbt,
-                    beneficiary,
-                )?;
-            }
-
             CtlMsg::FinalizeTransfers(FinalizeTransfersReq {
                 client_id,
                 transfers,
@@ -411,87 +384,6 @@ impl Runtime {
                 let _ =
                     self.send_rpc(endpoints, client_id, RpcMsg::OutpointState(transitions_info));
                 self.send_ctl(endpoints, ServiceId::rgbd(), CtlMsg::ProcessingComplete)?
-            }
-        }
-        Ok(())
-    }
-
-    fn handle_finalize_transfer(
-        &mut self,
-        endpoints: &mut Endpoints,
-        client_id: ClientId,
-        consignment: StateTransfer,
-        endseals: Vec<SealEndpoint>,
-        psbt: Psbt,
-        beneficiary: Option<NodeAddr>,
-    ) -> Result<(), DaemonError> {
-        match self.finalize_transfer(consignment, endseals, psbt) {
-            Err(err) => {
-                let _ = self.send_rpc(endpoints, client_id, err);
-                self.send_ctl(endpoints, ServiceId::rgbd(), CtlMsg::ProcessingFailed)?
-            }
-            Ok(transfer) => {
-                if let Some(beneficiary) = beneficiary {
-                    // 1. Containerize consignment
-                    // TODO: Make consignment containerization part of the RGB stdlib; use logical,
-                    //       not a size-chunking
-                    let data = transfer.consignment.strict_serialize()?;
-                    let mut chunk_ids = MediumVec::new();
-                    let size = data.len() as u64;
-                    for piece in data.chunks(u24::MAX.into_usize()) {
-                        let chunk = Chunk::try_from(piece)?;
-                        let chunk_id = chunk.chunk_id();
-                        self.store.store(storm_rpc::DB_TABLE_CHUNKS, chunk_id, &chunk)?;
-                        chunk_ids.push(chunk_id)?;
-                    }
-
-                    let header = ContainerHeader {
-                        version: 0,
-                        mime: AsciiString::from_str("application/vnd.lnpbp.rgb.consignment")
-                            .expect("hardcoded MIME type"),
-                        info: empty!(),
-                        size,
-                    };
-                    let header_chunk = Chunk::try_from(header.strict_serialize()?)?;
-                    let container = Container {
-                        header: header.clone(),
-                        chunks: chunk_ids,
-                    };
-                    let container_chunk = Chunk::try_from(container.strict_serialize()?)?;
-
-                    // 2. Upload container to stored database
-                    let container_id = container.container_id();
-                    self.store.store(
-                        storm_rpc::DB_TABLE_CONTAINER_HEADERS,
-                        container_id,
-                        &header_chunk,
-                    )?;
-                    self.store.store(
-                        storm_rpc::DB_TABLE_CONTAINERS,
-                        container_id,
-                        &container_chunk,
-                    )?;
-
-                    // 3. Instruct storm to send the consignment to the remote peer
-                    // TODO: Ensure we are connected to the beneficiary
-                    let container_full_id = ContainerFullId {
-                        // TODO: Change to use message-wrapped container announcements
-                        message_id: MesgId::default(),
-                        container_id,
-                    };
-                    let addressed_msg = AddressedMsg {
-                        remote_id: beneficiary.id,
-                        data: ContainerInfo {
-                            id: container_full_id,
-                            header,
-                        },
-                    };
-
-                    self.send_storm(endpoints, StormMsg::ContainerAnnouncement(addressed_msg))?;
-                }
-                let _ =
-                    self.send_rpc(endpoints, client_id, RpcMsg::StateTransferFinalize(transfer));
-                self.send_ctl(endpoints, ServiceId::rgbd(), CtlMsg::ProcessingComplete)?;
             }
         }
         Ok(())

--- a/src/bus/ctl.rs
+++ b/src/bus/ctl.rs
@@ -11,7 +11,6 @@
 use std::collections::BTreeSet;
 
 use bitcoin::{OutPoint, Txid};
-use internet2::addr::NodeAddr;
 use microservices::esb::ClientId;
 use psbt::Psbt;
 use rgb::schema::TransitionType;
@@ -50,9 +49,6 @@ pub enum CtlMsg {
 
     #[display(inner)]
     OutpointState(OutpointStateReq),
-
-    #[display(inner)]
-    FinalizeTransfer(FinalizeTransferReq),
 
     #[display(inner)]
     FinalizeTransfers(FinalizeTransfersReq),
@@ -108,17 +104,6 @@ pub struct ValidityResp {
 pub struct OutpointStateReq {
     pub client_id: ClientId,
     pub outpoints: BTreeSet<OutPoint>,
-}
-
-#[derive(Clone, PartialEq, Eq, Debug, Display)]
-#[derive(NetworkEncode, NetworkDecode)]
-#[display("finalize_transfer({client_id}, ...)")]
-pub struct FinalizeTransferReq {
-    pub client_id: ClientId,
-    pub consignment: StateTransfer,
-    pub endseals: Vec<SealEndpoint>,
-    pub psbt: Psbt,
-    pub beneficiary: Option<NodeAddr>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Display)]

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -16,8 +16,8 @@ use rgb_rpc::RpcMsg;
 use storm_ext::ExtMsg as StormMsg;
 
 pub use self::ctl::{
-    ConsignReq, CtlMsg, FinalizeTransferReq, FinalizeTransfersReq, OutpointStateReq,
-    ProcessDisclosureReq, ProcessReq, ValidityResp,
+    ConsignReq, CtlMsg, FinalizeTransfersReq, OutpointStateReq, ProcessDisclosureReq, ProcessReq,
+    ValidityResp,
 };
 pub use self::services::{DaemonId, ServiceId};
 pub(crate) use self::services::{Endpoints, Responder, ServiceBus};


### PR DESCRIPTION
I updated the current `rgb-cli transfer finalize`  to support multiple transfers with bifrost send option.

Before:
```
rgb-cli transfer finalize {PSBT} {CONSIGMENT} --endseal {SEAL_DEFINITION} --send {BIFROST_ADDR}
```

Now:
```
rgb-cli transfer finalize {PSBT}  --endseal "{SEAL_A}[,{SEAL_B}]:{CONSIGMENT_A}" --endseal "{SEAL_C}:{CONSIGMENT_B}" ...
```

Example:
```
rgb-cli transfer finalize /var/lib/rgb/atomic.psbt --endseal "$bob_seal,$charlie_seal:/var/lib/rgb/bob.rgbc" --endseal "$alice_seal,:/var/lib/rgb/alice.rgbc" ...
```

PS: @zoedberg I didn't modify finalize_transfers because I was afraid of breaking something in rgb-lib.
