### PR TITLE
fix panic for missing revealed txid

### DIFF
--- a/src/bucketd/processor.rs
+++ b/src/bucketd/processor.rs
@@ -371,10 +371,8 @@ impl Runtime {
                 self.store.store_sten(db::NODE_CONTRACTS, node_id, &contract_id)?;
 
                 for seal in new_transition.filter_revealed_seals() {
-                    let index_id = ChunkId::with_fixed_fragments(
-                        seal.txid.expect("seal should contain revealed txid"),
-                        seal.vout,
-                    );
+                    let index_id =
+                        ChunkId::with_fixed_fragments(seal.txid.unwrap_or(witness_txid), seal.vout);
                     self.store.insert_into_set(db::OUTPOINTS, index_id, node_id.into_array())?;
                 }
             }


### PR DESCRIPTION
We sent some assets from the [rgb-lightning-sample](https://github.com/RGB-Tools/rgb-lightning-sample) to an rgb-lib wallet and the latter failed with a panic on rgb-node (when calling `register_contract`). The panic comes from https://github.com/RGB-WG/rgb-node/blob/master/src/bucketd/processor.rs#L375 and says `seal should contain revealed txid`. This bug appears when the receiver registers a consignment that, in its history, has a `SealEndpoint::WitnessVout`.

@dr-orlovsky After merging this we would appreciate if you could release a `0.9.2` of rgb-node